### PR TITLE
support local esm-2 weights

### DIFF
--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -153,16 +153,22 @@ def calculate_checksum(file_path, algo="sha256") -> str:
     return h.hexdigest()
 
 
-def download_weights(url: str, dest: str, timeout: int = 10) -> None:
+def download_weights(url: str, dest_path: str) -> str:
     try:
-        response = requests.get(url, stream=True, timeout=timeout)
+        response = requests.get(url, stream=True)
         response.raise_for_status()
-        with open(dest, "wb") as f:
+        with open(dest_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-    except requests.RequestException:
-        pass
+                f.write(chunk)
+        if not os.path.exists(dest_path) or os.path.getsize(dest_path) == 0:
+            raise RuntimeError(
+                f"Downloaded file does not exist or is empty: {dest_path}"
+            )
+        return dest_path
+    except requests.RequestException as e:
+        raise RuntimeError(f"Failed to download weights from {url}: {e}")
+    except Exception as e:
+        raise RuntimeError(f"Unexpected error when trying to download the weights: {e}")
 
 
 def fetch_weights() -> str:

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -161,7 +161,7 @@ def download_weights(url: str, dest: str, timeout: int = 10) -> None:
             for chunk in response.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)
-    except:
+    except requests.RequestException:
         pass
 
 

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -1,3 +1,4 @@
+
 # Command line interface for predicting fnat
 import logging
 import os
@@ -155,7 +156,7 @@ def calculate_checksum(file_path, algo="sha256") -> str:
 
 def download_weights(url: str, dest_path: str) -> str:
     try:
-        esponse = requests.get(url, stream=True, timeout=10)
+        response = requests.get(url, stream=True, timeout=10)
         response.raise_for_status()
         with open(dest_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -155,7 +155,7 @@ def calculate_checksum(file_path, algo="sha256") -> str:
 
 def download_weights(url: str, dest_path: str) -> str:
     try:
-        response = requests.get(url, stream=True)
+        esponse = requests.get(url, stream=True, timeout=10)
         response.raise_for_status()
         with open(dest_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):


### PR DESCRIPTION

-To avoid downloading ESM-2 weights from torthhub each time a server job is submitted, the weights are handled now outside of esm-2;

The code checks for local weights first -- looks for weights in paths defined by the two environment variables. If no local weights are found, it will proceed to download them.