### PR TITLE
add build validation action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: validate docker build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: docker build .


### PR DESCRIPTION
This PR adds a new action to check if the docker image can be built as the latest builts have failed: https://github.com/haddocking/deeprank-gnn-esm/actions/workflows/docker-publish.yml and this is only visible after the release/tag is made.