### PR TITLE
Fix: Correct output file path generation in hdf5_to_csv.py

### DIFF
--- a/src/deeprank_gnn/tools/hdf5_to_csv.py
+++ b/src/deeprank_gnn/tools/hdf5_to_csv.py
@@ -6,7 +6,7 @@ import numpy as np
 def hdf5_to_csv(hdf5_path):
         
         hdf5 = h5py.File(hdf5_path,'r+')
-        name = hdf5_path.split('.')[0]
+        name = hdf5_path.rsplit('.', 1)[0]
         
         first = True
         for epoch in hdf5.keys():


### PR DESCRIPTION
This PR fixes a bug in the hdf5_to_csv.py script that caused an incorrect output file path to be generated when the input HDF5 file's directory path contained a dot (.), such as in a version number.

The script was using path.split('.') which split the entire path string. This has been changed to path.rsplit('.', 1) to ensure only the .hdf5 extension is removed, leaving the base path intact.
