### PR TITLE
use model name instead of model path in `get_embedding` 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deeprank-gnn-esm"
-version = "0.1.0"
+version = "0.3.0"
 description = "Graph Network for protein-protein interface including language model features"
 authors = [{ name = "Xiaotong Xu" }, { email = "x.xu1@uu.nl" }]
 maintainers = [{ name = "BonvinLab" }, { email = "bonvinlab.support@uu.nl" }]

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -1,34 +1,31 @@
 # Command line interface for predicting fnat
 import warnings
+
 from Bio import BiopythonWarning
 
 # Place warning filters BEFORE any Biopython imports that trigger warnings
 warnings.filterwarnings("ignore", category=BiopythonWarning)
 warnings.filterwarnings("ignore", message=".*deprecated.*")
 
+import argparse
+import importlib.util
 import logging
 import os
-import shutil
 import re
-import requests
+import shutil
 import tempfile
-import hashlib
 from io import TextIOWrapper
 from pathlib import Path
-import importlib.util
 from typing import List
-import argparse
-import torch
-from Bio.PDB import PDBParser, PDBIO, Structure, Model, Chain
-from Bio.PDB.Polypeptide import is_aa
 
+import torch
+from Bio.PDB import PDBIO, Chain, Model, PDBParser, Structure
 from esm import FastaBatchedDataset, pretrained
 
 from deeprank_gnn.ginet import GINet
 from deeprank_gnn.GraphGenMP import GraphHDF5
 from deeprank_gnn.NeuralNet import NeuralNet
 from deeprank_gnn.tools.hdf5_to_csv import hdf5_to_csv
-
 
 # Configure logging
 log = logging.getLogger(__name__)
@@ -42,11 +39,6 @@ log.addHandler(ch)
 
 
 ESM_MODEL = "esm2_t33_650M_UR50D"
-EXPECTED_CHECKSUMS = [
-    "ea9d0522b335a8778dea6535a65301f10208dece28cd5865482b0b1fc446168c",  # model.pt
-    "8ffe6edbd4173dc8d45c2cd5cb27d43aad77ec26b4c768200c58ae1f96693575",  # regression.pt
-]
-
 
 spec = importlib.util.find_spec("deeprank_gnn")
 if spec and spec.origin:
@@ -187,64 +179,6 @@ def pdb_to_fasta(pdb_file_path: Path, main_fasta_fh: TextIOWrapper) -> None:
         main_fasta_fh.write(f">{root}.{chain.id}\n{sequence}\n")
 
 
-def calculate_checksum(file_path, algo="sha256") -> str:
-    h = hashlib.new(algo)
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
-def download_weights(url: str, dest_path: str) -> str:
-    try:
-        response = requests.get(url, stream=True, timeout=10)
-        response.raise_for_status()
-        with open(dest_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-        if not os.path.exists(dest_path) or os.path.getsize(dest_path) == 0:
-            raise RuntimeError(
-                f"Downloaded file does not exist or is empty: {dest_path}"
-            )
-        return dest_path
-    except requests.RequestException as e:
-        raise RuntimeError(f"Failed to download weights from {url}: {e}")
-    except Exception as e:
-        raise RuntimeError(f"Unexpected error when trying to download the weights: {e}")
-
-
-def fetch_weights() -> str:
-    """Fetch the ESM model weights and regression weights."""
-    models = [
-        (
-            "WEIGHT_PATH",
-            f"{ESM_MODEL}.pt",
-            f"https://dl.fbaipublicfiles.com/fair-esm/models/{ESM_MODEL}.pt",
-            "ea9d0522b335a8778dea6535a65301f10208dece28cd5865482b0b1fc446168c",
-        ),
-        (
-            "REG_WEIGHT_PATH",
-            f"{ESM_MODEL}-contact-regression.pt",
-            f"https://dl.fbaipublicfiles.com/fair-esm/regression/{ESM_MODEL}-contact-regression.pt",
-            "8ffe6edbd4173dc8d45c2cd5cb27d43aad77ec26b4c768200c58ae1f96693575",
-        ),
-    ]
-
-    for env_var, filename, url, expected_checksum in models:
-        path = os.getenv(env_var)
-        if not path:  # catches None or empty string
-            path = filename
-
-        if not os.path.exists(path):
-            download_weights(url, path)
-
-        observed_checksum = calculate_checksum(path)
-        if observed_checksum != expected_checksum:
-            download_weights(url, path)
-
-    return f"{ESM_MODEL}.pt"
-
-
 # Helper function to process each batch
 def process_batch(labels, strs, output_dir, representations):
     embedd_path = []
@@ -286,10 +220,9 @@ def get_embedding(fasta_file: Path, output_dir: Path) -> List[Path]:
     log.info("Generating embedding for protein sequence.")
     log.info("#" * 80)
 
-    # Load model and alphabet
-    esm_path = fetch_weights()
-    model, alphabet = pretrained.load_model_and_alphabet(esm_path)
+    model, alphabet = pretrained.load_model_and_alphabet(ESM_MODEL)
     model.eval()
+
     if torch.cuda.is_available():
         model = model.cuda()
 
@@ -321,7 +254,12 @@ def get_embedding(fasta_file: Path, output_dir: Path) -> List[Path]:
 
             # Process the batch
             embedd_path.extend(
-                process_batch(labels, strs, output_dir, representations,)
+                process_batch(
+                    labels,
+                    strs,
+                    output_dir,
+                    representations,
+                )
             )
 
     log.info("#" * 80)
@@ -518,6 +456,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-
-

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,41 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from deeprank_gnn.predict import get_embedding
+
+
+class TestPredict(unittest.TestCase):
+    def test_get_embedding(self):
+        """Test that get_embedding generates embeddings correctly."""
+        # Create a temporary directory for test files
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+
+            # Create a simple fasta file with a short sequence
+            fasta_file = tmpdir / "test.fasta"
+            fasta_file.write_text(">test_seq.A\nMKTAYIAKQRQISFVKSHFSRQLE\n")
+
+            # Create output directory
+            output_dir = tmpdir / "embeddings"
+
+            # Generate embeddings
+            embed_paths = get_embedding(fasta_file, output_dir)
+
+            # Verify output
+            self.assertEqual(len(embed_paths), 1)
+            self.assertTrue(embed_paths[0].exists())
+            self.assertTrue(str(embed_paths[0]).endswith(".pt"))
+
+            # Load and verify the embedding file
+            result = torch.load(embed_paths[0])
+            self.assertIn("label", result)
+            self.assertIn("representations", result)
+            self.assertIn("mean_representations", result)
+            self.assertEqual(result["label"], "test_seq.A")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/haddocking/deeprank-gnn-esm/pull/21, in which the application itself would handle the download of the models. 

The previous implementation is correct, gives us much more control about how the download is made and cached but had the side-effect of greatly increasing the RAM usage.

By using the model name here instead of the model path we can offload the loading of the model to pytorch which has several optimizations to reduce the memory footprint. We unfortunately loose the control over the downloads but we reduce the footprint significantly.