### PR TITLE
replace lambda function for mac compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ on:
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: true
 
@@ -37,7 +38,7 @@ jobs:
 
       - uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         if: >-
-          ${{ matrix.python-version == '3.11' && (
+          ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' && (
           github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository) }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Only test older and newer supported versions
+        python-version: ["3.9", "3.13"]
       fail-fast: true
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deeprank-gnn-esm"
-version = "1.0.0"
+version = "1.0.1"
 description = "Graph Network for protein-protein interface including language model features"
 authors = [{ name = "Xiaotong Xu" }, { email = "x.xu1@uu.nl" }]
 maintainers = [{ name = "BonvinLab" }, { email = "bonvinlab.support@uu.nl" }]

--- a/src/deeprank_gnn/DataSet.py
+++ b/src/deeprank_gnn/DataSet.py
@@ -11,6 +11,10 @@ import copy
 from .community_pooling import community_detection, community_pooling
 
 
+def _default_edge_feature_transform(x):
+    return np.tanh(-x / 2 + 2) + 1
+
+
 def DivideDataSet(dataset, percent=[0.8, 0.2], shuffle=True):
     """Divides the dataset into a training set and an evaluation set
 
@@ -101,7 +105,7 @@ class HDF5DataSet(Dataset):
         node_feature="all",
         edge_feature=["dist"],
         clustering_method="mcl",
-        edge_feature_transform=lambda x: np.tanh(-x / 2 + 2) + 1,
+        edge_feature_transform=_default_edge_feature_transform,
     ):
         """Class from which the hdf5 datasets are loaded.
 


### PR DESCRIPTION
when doing https://github.com/haddocking/haddock3/pull/1480 I saw the actions were failing on macos with the error:
```
_pickle.PicklingError: Can't pickle <function HDF5DataSet.<lambda> at 0x1130d62a0>: attribute lookup HDF5DataSet.<lambda> on deeprank_gnn.DataSet failed
```

The solution to this is very simple, this `HDF5DataSet` is taking a lambda function as an argument into an object that is being passed to a multiprocessing worker. This works fine or linux but mac (for some reason) cannot handle the lambda assignment directly - so the fix is to simply pass it as a function instead.