### PR TITLE
add `sqlite3` check at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ at <https://arxiv.org/abs/2407.16375>
 pip install deeprank-gnn-esm
 ```
 
+### Requirements
+
+Your Python interpreter must be compiled with `sqlite3` support (needed by `pdb2sql`
+for structure interface calculations). Most system Python installs already include
+this; check with::
+
+```bash
+python -c "import sqlite3"
+```
+
+If this raises `ModuleNotFoundError: No module named '_sqlite3'`, rebuild or
+reinstall Python with `sqlite3` support.
+
 ### CPU only
 
 To avoid downloading the heavy CUDA libraries (~3GB), install the CPU-only `torch` first:

--- a/src/deeprank_gnn/__init__.py
+++ b/src/deeprank_gnn/__init__.py
@@ -1,0 +1,6 @@
+try:
+    import sqlite3  # noqa: F401
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "deeprank_gnn requires a Python interpreter compiled with sqlite3 support "
+    ) from e


### PR DESCRIPTION
this PR adds a runtime check at initialized to evaluate if the current python interpreter was compiled with `sqlite3` support as this is needed for `pdb2sql` and if not present will fail cryptically downstream.

most full python installations will have this but this might not be the case in all systems, this check makes this dependency clear.