### PR TITLE
refactor embedding generation pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,26 @@ jobs:
       - name: install package with dev dependencies
         run: uv pip install --system ".[dev]"
 
-      - name: run tests
+      - name: run unit tests
         run: >-
-          pytest --cov
+          pytest -m "not e2e"
+          --cov
           --cov-report xml:coverage.xml
           --cov-append
           -vv
           --hypothesis-show-statistics
 
+      - name: run end-to-end tests
+        run: >-
+          pytest -m e2e
+          --cov
+          --cov-report xml:coverage.xml
+          --cov-append
+          -vv
+
       - uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
         if: >-
-          ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest' && (
+          ${{ matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && (
           github.event_name != 'pull_request' ||
           github.event.pull_request.head.repo.full_name == github.repository) }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
           -vv
           --hypothesis-show-statistics
 
+      - name: cache ESM model checkpoint
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/torch/hub/checkpoints
+          key: esm2_t33_650M_UR50D
+
       - name: run end-to-end tests
         if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           --hypothesis-show-statistics
 
       - name: run end-to-end tests
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
         run: >-
           pytest -m e2e
           --cov

--- a/README.md
+++ b/README.md
@@ -62,21 +62,28 @@ Check [pytorch.org](https://pytorch.org/get-started/locally/) for the right CUDA
 ### As a scoring function
 
 We provide a command-line interface for `deeprank-gnn-esm` that can easily be
-used to score protein-protein complexes. The command-line interface can be used
-as follows:
+used to score protein-protein complexes. It accepts one or more PDB files
+(each optionally a multi-model ensemble) in a single invocation. Every pair
+of chains in each input structure is scored as a separate interface - a
+3-chain complex produces 3 pairwise predictions (A-B, A-C, B-C), an ensemble
+of N models produces predictions for every model. The command-line interface
+can be used as follows:
 
 ```bash
 $ deeprank-gnn-esm-predict -h
-usage: deeprank-gnn-esm-predict [-h] pdb_file chain_id_1 chain_id_2 num_cores
+usage: deeprank-gnn-esm-predict [-h] [--num_cores NUM_CORES] [--output-dir OUTPUT_DIR]
+                                 pdb_files [pdb_files ...]
 
 positional arguments:
-  pdb_file    Path to the PDB file.
-  chain_id_1  First chain ID.
-  chain_id_2  Second chain ID.
-  num_cores   Number of cores 
+  pdb_files             Path(s) to the PDB file(s).
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
+  --num_cores NUM_CORES
+                        Number of cores to use (default: 1)
+  --output-dir OUTPUT_DIR
+                        Directory to save intermediate files in (default: a
+                        temporary directory that is discarded after the run).
 ```
 
 Example, score the `1B6C` complex
@@ -85,43 +92,57 @@ Example, score the `1B6C` complex
 # download it
 $ wget https://files.rcsb.org/view/1B6C.pdb -q
 
-$ deeprank-gnn-esm-predict 1B6C.pdb A B 1
- 2023-06-28 06:08:21,889 predict:64 INFO - Setting up workspace - /home/deeprank-gnn-esm/1B6C-gnn_esm_pred_A_B
- 2023-06-28 06:08:21,945 predict:72 INFO - Renumbering PDB file.
- 2023-06-28 06:08:22,294 predict:104 INFO - Reading sequence of PDB 1B6C.pdb
- 2023-06-28 06:08:22,423 predict:131 INFO - Generating embedding for protein sequence.
- 2023-06-28 06:08:22,423 predict:132 INFO - ################################################################################
- 2023-06-28 06:08:32,447 predict:138 INFO - Transferred model to GPU
- 2023-06-28 06:08:32,450 predict:147 INFO - Read /home/1B6C-gnn_esm_pred_A_B/all.fasta with 2 sequences
- 2023-06-28 06:08:32,459 predict:157 INFO - Processing 1 of 1 batches (2 sequences)
- 2023-06-28 06:08:36,462 predict:200 INFO - ################################################################################
- 2023-06-28 06:08:36,470 predict:205 INFO - Generating graph, using 79 processors
- Graphs added to the HDF5 file
- Embedding added to the /home/1B6C-gnn_esm_pred_A_B/graph.hdf5 file file
- 2023-06-28 06:09:03,345 predict:220 INFO - Graph file generated: /home/deeprank-gnn-esm/1B6C-gnn_esm_pred_A_B/graph.hdf5
- 2023-06-28 06:09:03,345 predict:226 INFO - Predicting fnat of protein complex.
- 2023-06-28 06:09:03,345 predict:234 INFO - Using device: cuda:0
+$ deeprank-gnn-esm-predict 1B6C.pdb
+ 2026-07-22 06:08:21,889 predict:41 INFO - Setting up workspace - /tmp/tmpabcd1234
+ 2026-07-22 06:08:21,945 input:49 INFO - Renumbering structure 1B6C.
+ 2026-07-22 06:08:22,294 input:99 INFO - Reading sequence of structure 1B6C
+ 2026-07-22 06:08:22,423 sequence:57 INFO - Generating embeddings for 2 unique sequence(s).
+ 2026-07-22 06:08:32,459 input:212 INFO - Wrote 1 chain-pair PDB(s) of structure 1B6C to /tmp/tmpabcd1234/structures
+ 2026-07-22 06:08:36,470 predict:48 INFO - Generating graph, using 1 processors
+ 2026-07-22 06:09:03,345 predict:63 INFO - Graph file generated: /tmp/tmpabcd1234/graph.hdf5
+ 2026-07-22 06:09:03,345 predict:69 INFO - Predicting fnat of protein complex.
+ 2026-07-22 06:09:03,345 predict:77 INFO - Using device: cuda:0
  # ...
- 2023-06-28 06:09:07,794 predict:280 INFO - Predicted fnat for 1B6C between chainA and chainB: 0.359
- 2023-06-28 06:09:07,803 predict:290 INFO - Output written to /home/deeprank-gnn-esm/1B6C-gnn_esm_pred/GNN_esm_prediction.csv
+ 2026-07-22 06:09:07,794 predict:130 INFO - Predicted fnat for 1B6C between chain A and chain B: 0.359
+ 2026-07-22 06:09:07,803 predict:141 INFO - Output written to /tmp/tmpabcd1234/GNN_esm_prediction.csv
+ 2026-07-22 06:09:07,805 main:71 INFO - Result saved to /home/deeprank-gnn-esm/GNN_esm_prediction.csv
 ```
 
 From the output above you can see that the predicted fnat for the 1B6C
 complex is **0.359**, this information is also written to the
-`GNN_esm_prediction.csv` file.
-
-The command above will generate a folder in the current working directory,
-containing the following:
+`GNN_esm_prediction.csv` file in the directory you ran the command from:
 
 ```text
-1B6C-gnn_esm_pred_A_B
-├── 1B6C.pdb                   #input pdb file
-├── all.fasta                  #fasta sequence for the pdb input
-├── 1B6C.A.pt                  #esm-2 embedding for chainA in protein 1B6C
-├── 1B6C.B.pt                  #esm-2 embedding for chainB in protein 1B6C
+pdb_id,chain_i,chain_j,predicted_fnat
+1B6C,A,B,0.359
+```
+
+By default all intermediate files (renumbered PDB, per-chain embeddings,
+per-pair PDBs, graph/prediction hdf5) live in a temporary directory that's
+removed once the run finishes. Pass `--output-dir` to keep them around for
+inspection instead:
+
+```bash
+$ deeprank-gnn-esm-predict 1B6C.pdb --output-dir 1B6C-gnn_esm_pred
+```
+
+```text
+1B6C-gnn_esm_pred
+├── 1B6C.pdb                   #renumbered copy of the input pdb file
+├── 1B6C.A.pt                  #esm-2 embedding for chain A in protein 1B6C
+├── 1B6C.B.pt                  #esm-2 embedding for chain B in protein 1B6C
+├── structures/
+│   └── 1B6C_A-B.pdb           #2-chain pdb materialized for the A-B interface
 ├── graph.hdf5                 #input protein graph in hdf5 format
 ├── GNN_esm_prediction.hdf5    #prediction output in hdf5 format
 └── GNN_esm_prediction.csv     #prediction output in csv format
+```
+
+Multiple PDB files (including multi-model ensembles) can be scored in one
+call - each input must have a unique filename stem:
+
+```bash
+$ deeprank-gnn-esm-predict 1B6C.pdb ensemble.pdb --num_cores 4
 ```
 
 ### As a framework

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deeprank-gnn-esm"
-version = "1.1.0"
+version = "2.0.0"
 description = "Graph Network for protein-protein interface including language model features"
 authors = [{ name = "Xiaotong Xu" }, { email = "x.xu1@uu.nl" }]
 maintainers = [{ name = "BonvinLab" }, { email = "bonvinlab.support@uu.nl" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ keywords = [
 dev = ["pytest>=7.4.0", "pytest-cov>=4.0.0", "hypothesis>=6.0.0"]
 
 [project.scripts]
-deeprank-gnn-esm-predict = "deeprank_gnn.predict:main"
+deeprank-gnn-esm-predict = "deeprank_gnn.main:main"
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ deeprank-gnn-esm-predict = "deeprank_gnn.main:main"
 [tool.pytest.ini_options]
 markers = [
   "gpu: mark test as requiring a CUDA-capable GPU (skip with -m 'not gpu')",
+  "e2e: mark test as a full pipeline run (downloads/loads the ESM model, slower)",
 ]
 
 [build-system]

--- a/src/deeprank_gnn/input.py
+++ b/src/deeprank_gnn/input.py
@@ -2,6 +2,8 @@
 data structure carried through the DeepRank-GNN-esm prediction pipeline."""
 
 import logging
+import shutil
+from itertools import combinations
 from pathlib import Path
 
 import torch
@@ -54,7 +56,7 @@ class PDBInput:
             new_model = Model.Model(model.id)
 
             for chain in model:
-                new_chain = Chain.Chain(chain.id)
+                new_chain = Chain(chain.id)
 
                 residue_number = 1
                 for res in chain:
@@ -132,23 +134,72 @@ class PDBInput:
         away - matching the naming GraphGenMP._add_embedding expects on disk."""
         return self._multi_fasta.write_embeddings(embeddings, output_dir)
 
-    def write_models(self, output_dir: Path) -> list:
-        """Write one single-model PDB file per model to output_dir, named to
-        match to_multi_fasta()'s label roots. Needed because downstream graph
-        generation (GraphHDF5/pdb2sql) reads real single-model PDB files
-        from disk, not in-memory Structures."""
-        output_dir.mkdir(parents=True, exist_ok=True)
+    def chain_pairs(self, model) -> list[tuple[str, str]]:
+        """All unordered chain-id pairs for a given model. The GNN predicts
+        fnat for a single two-chain interface, so a >2-chain model is scored
+        one pair at a time."""
+        chain_ids = sorted(chain.id for chain in model)
+        return list(combinations(chain_ids, 2))
+
+    def pair_name(self, model, chain_a: str, chain_b: str) -> str:
+        """Root name used for a given model/chain-pair's PDB/embedding/graph
+        entries."""
+        return f"{self.model_name(model)}_{chain_a}-{chain_b}"
+
+    def write_chain_pairs(
+        self, pdb_dir: Path, embedding_dir: Path
+    ) -> dict[str, tuple[str, str, str]]:
+        """Write one 2-chain PDB file per chain pair of each model to pdb_dir,
+        and copy that pair's per-chain embedding files (already written by
+        write_embeddings to embedding_dir) under matching pair-root names.
+
+        Needed because downstream graph generation (GraphHDF5/pdb2sql) scores
+        one two-chain interface per PDB file on disk, and GraphGenMP looks up
+        embeddings as "{pdb file stem}.{chain_id}.pt". Each written pair is
+        also relabeled to chain ids A/B, since pdb2sql.interface's contact
+        search defaults to (and only supports) chain1='A', chain2='B' -
+        original chain ids are kept only in the returned mapping, for
+        reporting.
+
+        Returns {pair_root: (pdb_id, chain_a, chain_b)} (original chain ids)
+        for every pair written.
+        """
+        pdb_dir.mkdir(parents=True, exist_ok=True)
 
         io = PDBIO()
-        saved_files = []
+        pair_info: dict[str, tuple[str, str, str]] = {}
+
         for model in self.models:
-            root = self.model_name(model)
-            output_file = output_dir / f"{root}.pdb"
-            io.set_structure(model)
-            io.save(str(output_file))
-            saved_files.append(output_file)
+            model_root = self.model_name(model)
+
+            for chain_a, chain_b in self.chain_pairs(model):
+                root = self.pair_name(model, chain_a, chain_b)
+
+                pair_structure = Structure.Structure(root)
+                pair_model = Model.Model(model.id)
+                for chain in model:
+                    if chain.id == chain_a:
+                        relabeled = chain.copy()
+                        relabeled.id = "A"
+                        pair_model.add(relabeled)
+                    elif chain.id == chain_b:
+                        relabeled = chain.copy()
+                        relabeled.id = "B"
+                        pair_model.add(relabeled)
+                pair_structure.add(pair_model)
+
+                io.set_structure(pair_structure)
+                io.save(str(pdb_dir / f"{root}.pdb"))
+
+                for chain_id, relabeled_id in ((chain_a, "A"), (chain_b, "B")):
+                    shutil.copyfile(
+                        embedding_dir / f"{model_root}.{chain_id}.pt",
+                        embedding_dir / f"{root}.{relabeled_id}.pt",
+                    )
+
+                pair_info[root] = (model_root, chain_a, chain_b)
 
         log.info(
-            f"Wrote {len(saved_files)} model(s) of structure {self.name} to {output_dir}"
+            f"Wrote {len(pair_info)} chain-pair PDB(s) of structure {self.name} to {pdb_dir}"
         )
-        return saved_files
+        return pair_info

--- a/src/deeprank_gnn/input.py
+++ b/src/deeprank_gnn/input.py
@@ -1,0 +1,254 @@
+"""PDBInput: wraps a (possibly multi-model) Biopython Structure as the main
+data structure carried through the DeepRank-GNN-esm prediction pipeline."""
+
+import logging
+from io import TextIOWrapper
+from pathlib import Path
+
+import torch
+from Bio.PDB import PDBIO, Chain, Model, PDBParser, Structure
+from esm import FastaBatchedDataset, pretrained
+
+log = logging.getLogger(__name__)
+
+ESM_MODEL = "esm2_t33_650M_UR50D"
+TOKS_PER_BATCH = 4096
+REPR_LAYERS = [33]
+TRUNCATION_SEQ_LENGTH = 2500
+
+
+def three_to_one() -> dict:
+    """three_to_one mapping of 20 standard amino acids."""
+    return {
+        "ALA": "A",
+        "ARG": "R",
+        "ASN": "N",
+        "ASP": "D",
+        "CYS": "C",
+        "GLN": "Q",
+        "GLU": "E",
+        "GLY": "G",
+        "HIS": "H",
+        "ILE": "I",
+        "LEU": "L",
+        "LYS": "K",
+        "MET": "M",
+        "PHE": "F",
+        "PRO": "P",
+        "SER": "S",
+        "THR": "T",
+        "TRP": "W",
+        "TYR": "Y",
+        "VAL": "V",
+    }
+
+
+class PDBInput:
+    """A possibly multi-model PDB structure carried through renumbering,
+    FASTA/embedding generation, and per-model materialization for graph
+    generation."""
+
+    def __init__(self, structure: Structure.Structure, name: str):
+        self.structure = structure
+        self.name = name
+        self.label_map: dict[str, str] = {}  # set by to_fasta()
+        self.sequences: dict[
+            str, str
+        ] = {}  # set by to_fasta(): embedded label -> sequence
+
+    @classmethod
+    def from_file(cls, pdb_file_path: Path) -> "PDBInput":
+        """Parse a PDB file into a PDBInput."""
+        parser = PDBParser(QUIET=True)
+        structure = parser.get_structure(pdb_file_path.stem, pdb_file_path)
+        return cls(structure=structure, name=pdb_file_path.stem)
+
+    @property
+    def models(self) -> list:
+        return list(self.structure)
+
+    @property
+    def is_ensemble(self) -> bool:
+        return len(self.models) > 1
+
+    def model_name(self, model) -> str:
+        """Root name used for a given model's FASTA/embedding/PDB entries."""
+        return f"{self.name}_model{model.id}" if self.is_ensemble else self.name
+
+    def renumber(self) -> "PDBInput":
+        """Renumber residues in each chain of each model starting from 1
+        with no gaps, mutating this instance's structure in place."""
+        log.info(f"Renumbering structure {self.name}.")
+
+        new_structure = Structure.Structure("renumbered_structure")
+
+        for model in self.structure:
+            new_model = Model.Model(model.id)
+
+            for chain in model:
+                new_chain = Chain.Chain(chain.id)
+
+                residue_number = 1
+                for res in chain:
+                    res = res.copy()
+                    h, num, ins = res.id
+                    res.id = (h, residue_number, ins)
+                    new_chain.add(res)
+                    residue_number += 1
+
+                new_model.add(new_chain)
+
+            new_structure.add(new_model)
+
+        self.structure = new_structure
+        return self
+
+    def to_fasta(self, main_fasta_fh: TextIOWrapper) -> dict[str, str]:
+        """Write one FASTA entry per unique sequence found across all
+        models/chains of this structure.
+
+        Identical sequences (e.g. repeated across ensemble models, or
+        homodimer chains) are written once. Sets and returns self.label_map,
+        mapping every "{root}.{chain_id}" label to the label actually
+        written to the FASTA (and thus embedded) for its sequence.
+        """
+        log.info(f"Reading sequence of structure {self.name}")
+
+        seq_to_label: dict[str, str] = {}  # sequence -> label written to the FASTA
+        label_map: dict[str, str] = {}  # every label -> label actually embedded
+
+        for model in self.models:
+            root = self.model_name(model)
+
+            for chain in model:
+                sequence = ""
+                modified_residue_count = 0  # Track modified residues
+
+                for residue in chain:
+                    resname = residue.get_resname()
+                    try:
+                        sequence += three_to_one()[resname]
+                    except KeyError:
+                        sequence += "X"  # Unknown or modified residue
+                        modified_residue_count += 1
+
+                if modified_residue_count > 0:
+                    log.info(
+                        f"{modified_residue_count} unrecognized residues found in chain {chain.id} "
+                        f"of {root}. Use DeepRank-GNN-esm with caution: non-standard residues are not officially supported."
+                    )
+
+                label = f"{root}.{chain.id}"
+
+                if sequence in seq_to_label:
+                    # Same sequence already written under another label - reuse its embedding.
+                    label_map[label] = seq_to_label[sequence]
+                else:
+                    seq_to_label[sequence] = label
+                    label_map[label] = label
+                    self.sequences[label] = sequence
+                    main_fasta_fh.write(f">{label}\n{sequence}\n")
+
+        self.label_map = label_map
+        return label_map
+
+    def gen_embeddings(self, workspace_path: Path) -> list[tuple[str, torch.Tensor]]:
+        """Generate ESM embeddings for every unique sequence in this structure.
+
+        Writes the deduplicated multi-FASTA to workspace_path (via to_fasta),
+        runs ESM once over it, and returns one (sequence, embedding) pair per
+        unique sequence - one ESM call per unique sequence, not per chain/model.
+        """
+        workspace_path.mkdir(parents=True, exist_ok=True)
+        fasta_path = workspace_path / f"{self.name}.fasta"
+
+        self.sequences = {}
+        with open(fasta_path, "w") as fh:
+            self.to_fasta(fh)
+
+        log.info(f"Generating embeddings for {len(self.sequences)} unique sequence(s).")
+
+        model, alphabet = pretrained.load_model_and_alphabet(ESM_MODEL)
+        model.eval()
+        if torch.cuda.is_available():
+            model = model.cuda()
+
+        dataset = FastaBatchedDataset.from_file(fasta_path)
+        batches = dataset.get_batch_indices(TOKS_PER_BATCH, extra_toks_per_seq=1)
+        data_loader = torch.utils.data.DataLoader(
+            dataset,
+            collate_fn=alphabet.get_batch_converter(TRUNCATION_SEQ_LENGTH),
+            batch_sampler=batches,
+        )
+
+        repr_layers = [
+            (i + model.num_layers + 1) % (model.num_layers + 1) for i in REPR_LAYERS
+        ]
+        last_layer = repr_layers[-1]
+
+        results: list[tuple[str, torch.Tensor]] = []
+        with torch.no_grad():
+            for labels, strs, toks in data_loader:
+                if torch.cuda.is_available():
+                    toks = toks.to("cuda", non_blocking=True)
+
+                out = model(toks, repr_layers=repr_layers, return_contacts=False)
+                representations = {
+                    layer: t.cpu() for layer, t in out["representations"].items()
+                }
+
+                for i, label in enumerate(labels):
+                    truncate_len = min(TRUNCATION_SEQ_LENGTH, len(strs[i]))
+                    embedding = representations[last_layer][
+                        i, 1 : truncate_len + 1
+                    ].clone()
+                    results.append((self.sequences[label], embedding))
+
+        return results
+
+    def write_embeddings(
+        self, embeddings: list[tuple[str, torch.Tensor]], output_dir: Path
+    ) -> list[Path]:
+        """Persist gen_embeddings() output as one {root}.{chain_id}.pt file per
+        model/chain label - including labels whose sequence was deduplicated
+        away by to_fasta() - matching the naming GraphGenMP._add_embedding
+        expects on disk."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        seq_to_embedding = {sequence: embedding for sequence, embedding in embeddings}
+
+        saved_files = []
+        for label, canonical_label in self.label_map.items():
+            sequence = self.sequences[canonical_label]
+            embedding = seq_to_embedding[sequence]
+
+            output_file = output_dir / f"{label}.pt"
+            torch.save(
+                {"label": label, "representations": {REPR_LAYERS[-1]: embedding}},
+                output_file,
+            )
+            saved_files.append(output_file)
+
+        log.info(f"Wrote {len(saved_files)} embedding file(s) to {output_dir}")
+        return saved_files
+
+    def write_models(self, output_dir: Path) -> list:
+        """Write one single-model PDB file per model to output_dir, named to
+        match to_fasta()'s label roots. Needed because downstream graph
+        generation (GraphHDF5/pdb2sql) reads real single-model PDB files
+        from disk, not in-memory Structures."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        io = PDBIO()
+        saved_files = []
+        for model in self.models:
+            root = self.model_name(model)
+            output_file = output_dir / f"{root}.pdb"
+            io.set_structure(model)
+            io.save(str(output_file))
+            saved_files.append(output_file)
+
+        log.info(
+            f"Wrote {len(saved_files)} model(s) of structure {self.name} to {output_dir}"
+        )
+        return saved_files

--- a/src/deeprank_gnn/input.py
+++ b/src/deeprank_gnn/input.py
@@ -2,45 +2,16 @@
 data structure carried through the DeepRank-GNN-esm prediction pipeline."""
 
 import logging
-from io import TextIOWrapper
 from pathlib import Path
 
 import torch
-from Bio.PDB import PDBIO, Chain, Model, PDBParser, Structure
-from esm import FastaBatchedDataset, pretrained
+from Bio.Data.PDBData import protein_letters_3to1
+from Bio.PDB import PDBIO, Model, PDBParser, Structure
+from Bio.PDB.Chain import Chain
+
+from deeprank_gnn.sequence import MultiFasta, Sequence
 
 log = logging.getLogger(__name__)
-
-ESM_MODEL = "esm2_t33_650M_UR50D"
-TOKS_PER_BATCH = 4096
-REPR_LAYERS = [33]
-TRUNCATION_SEQ_LENGTH = 2500
-
-
-def three_to_one() -> dict:
-    """three_to_one mapping of 20 standard amino acids."""
-    return {
-        "ALA": "A",
-        "ARG": "R",
-        "ASN": "N",
-        "ASP": "D",
-        "CYS": "C",
-        "GLN": "Q",
-        "GLU": "E",
-        "GLY": "G",
-        "HIS": "H",
-        "ILE": "I",
-        "LEU": "L",
-        "LYS": "K",
-        "MET": "M",
-        "PHE": "F",
-        "PRO": "P",
-        "SER": "S",
-        "THR": "T",
-        "TRP": "W",
-        "TYR": "Y",
-        "VAL": "V",
-    }
 
 
 class PDBInput:
@@ -51,10 +22,7 @@ class PDBInput:
     def __init__(self, structure: Structure.Structure, name: str):
         self.structure = structure
         self.name = name
-        self.label_map: dict[str, str] = {}  # set by to_fasta()
-        self.sequences: dict[
-            str, str
-        ] = {}  # set by to_fasta(): embedded label -> sequence
+        self._multi_fasta = MultiFasta()  # set by to_multi_fasta()
 
     @classmethod
     def from_file(cls, pdb_file_path: Path) -> "PDBInput":
@@ -103,138 +71,70 @@ class PDBInput:
         self.structure = new_structure
         return self
 
-    def to_fasta(self, main_fasta_fh: TextIOWrapper) -> dict[str, str]:
-        """Write one FASTA entry per unique sequence found across all
-        models/chains of this structure.
+    @staticmethod
+    def _chain_to_seq(chain: Chain) -> str:
+        sequence = ""
+
+        for residue in chain:
+            resname = residue.get_resname()
+            if resname in protein_letters_3to1:
+                sequence += protein_letters_3to1[resname]
+            else:
+                sequence += "X"  # Unknown/modified residue
+
+        return sequence
+
+    def to_multi_fasta(self) -> MultiFasta:
+        """Build one Sequence per model/chain of this structure and dedup
+        them by content into self._multi_fasta.
 
         Identical sequences (e.g. repeated across ensemble models, or
-        homodimer chains) are written once. Sets and returns self.label_map,
-        mapping every "{root}.{chain_id}" label to the label actually
-        written to the FASTA (and thus embedded) for its sequence.
+        homodimer chains) are kept once. self._multi_fasta.label_map maps
+        every "{root}.{chain_id}" label to the label actually embedded for
+        its sequence.
         """
         log.info(f"Reading sequence of structure {self.name}")
 
-        seq_to_label: dict[str, str] = {}  # sequence -> label written to the FASTA
-        label_map: dict[str, str] = {}  # every label -> label actually embedded
+        self._multi_fasta = MultiFasta()
 
         for model in self.models:
             root = self.model_name(model)
 
             for chain in model:
-                sequence = ""
-                modified_residue_count = 0  # Track modified residues
+                label = f"{root}.{chain.id}"
+                seq_obj = Sequence(label=label, sequence=self._chain_to_seq(chain))
 
-                for residue in chain:
-                    resname = residue.get_resname()
-                    try:
-                        sequence += three_to_one()[resname]
-                    except KeyError:
-                        sequence += "X"  # Unknown or modified residue
-                        modified_residue_count += 1
-
-                if modified_residue_count > 0:
-                    log.info(
-                        f"{modified_residue_count} unrecognized residues found in chain {chain.id} "
+                if seq_obj.modified_residue_count > 0:
+                    log.warning(
+                        f"Unrecognized residues found in chain {chain.id} "
                         f"of {root}. Use DeepRank-GNN-esm with caution: non-standard residues are not officially supported."
                     )
 
-                label = f"{root}.{chain.id}"
+                self._multi_fasta.add(seq_obj)
 
-                if sequence in seq_to_label:
-                    # Same sequence already written under another label - reuse its embedding.
-                    label_map[label] = seq_to_label[sequence]
-                else:
-                    seq_to_label[sequence] = label
-                    label_map[label] = label
-                    self.sequences[label] = sequence
-                    main_fasta_fh.write(f">{label}\n{sequence}\n")
+        return self._multi_fasta
 
-        self.label_map = label_map
-        return label_map
-
-    def gen_embeddings(self, workspace_path: Path) -> list[tuple[str, torch.Tensor]]:
+    def gen_embeddings(self) -> list[tuple[str, torch.Tensor]]:
         """Generate ESM embeddings for every unique sequence in this structure.
 
-        Writes the deduplicated multi-FASTA to workspace_path (via to_fasta),
-        runs ESM once over it, and returns one (sequence, embedding) pair per
-        unique sequence - one ESM call per unique sequence, not per chain/model.
+        Builds the deduplicated MultiFasta (via to_multi_fasta) and delegates
+        the ESM run to it - one ESM call per unique sequence, not per
+        chain/model.
         """
-        workspace_path.mkdir(parents=True, exist_ok=True)
-        fasta_path = workspace_path / f"{self.name}.fasta"
-
-        self.sequences = {}
-        with open(fasta_path, "w") as fh:
-            self.to_fasta(fh)
-
-        log.info(f"Generating embeddings for {len(self.sequences)} unique sequence(s).")
-
-        model, alphabet = pretrained.load_model_and_alphabet(ESM_MODEL)
-        model.eval()
-        if torch.cuda.is_available():
-            model = model.cuda()
-
-        dataset = FastaBatchedDataset.from_file(fasta_path)
-        batches = dataset.get_batch_indices(TOKS_PER_BATCH, extra_toks_per_seq=1)
-        data_loader = torch.utils.data.DataLoader(
-            dataset,
-            collate_fn=alphabet.get_batch_converter(TRUNCATION_SEQ_LENGTH),
-            batch_sampler=batches,
-        )
-
-        repr_layers = [
-            (i + model.num_layers + 1) % (model.num_layers + 1) for i in REPR_LAYERS
-        ]
-        last_layer = repr_layers[-1]
-
-        results: list[tuple[str, torch.Tensor]] = []
-        with torch.no_grad():
-            for labels, strs, toks in data_loader:
-                if torch.cuda.is_available():
-                    toks = toks.to("cuda", non_blocking=True)
-
-                out = model(toks, repr_layers=repr_layers, return_contacts=False)
-                representations = {
-                    layer: t.cpu() for layer, t in out["representations"].items()
-                }
-
-                for i, label in enumerate(labels):
-                    truncate_len = min(TRUNCATION_SEQ_LENGTH, len(strs[i]))
-                    embedding = representations[last_layer][
-                        i, 1 : truncate_len + 1
-                    ].clone()
-                    results.append((self.sequences[label], embedding))
-
-        return results
+        self.to_multi_fasta()
+        return self._multi_fasta.gen_embeddings()
 
     def write_embeddings(
         self, embeddings: list[tuple[str, torch.Tensor]], output_dir: Path
     ) -> list[Path]:
         """Persist gen_embeddings() output as one {root}.{chain_id}.pt file per
         model/chain label - including labels whose sequence was deduplicated
-        away by to_fasta() - matching the naming GraphGenMP._add_embedding
-        expects on disk."""
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        seq_to_embedding = {sequence: embedding for sequence, embedding in embeddings}
-
-        saved_files = []
-        for label, canonical_label in self.label_map.items():
-            sequence = self.sequences[canonical_label]
-            embedding = seq_to_embedding[sequence]
-
-            output_file = output_dir / f"{label}.pt"
-            torch.save(
-                {"label": label, "representations": {REPR_LAYERS[-1]: embedding}},
-                output_file,
-            )
-            saved_files.append(output_file)
-
-        log.info(f"Wrote {len(saved_files)} embedding file(s) to {output_dir}")
-        return saved_files
+        away - matching the naming GraphGenMP._add_embedding expects on disk."""
+        return self._multi_fasta.write_embeddings(embeddings, output_dir)
 
     def write_models(self, output_dir: Path) -> list:
         """Write one single-model PDB file per model to output_dir, named to
-        match to_fasta()'s label roots. Needed because downstream graph
+        match to_multi_fasta()'s label roots. Needed because downstream graph
         generation (GraphHDF5/pdb2sql) reads real single-model PDB files
         from disk, not in-memory Structures."""
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/src/deeprank_gnn/logger.py
+++ b/src/deeprank_gnn/logger.py
@@ -8,4 +8,6 @@ _formatter = logging.Formatter(
     " %(asctime)s %(module)s:%(lineno)d %(levelname)s - %(message)s"
 )
 _ch.setFormatter(_formatter)
-log.addHandler(_ch)
+
+if not log.handlers:
+    log.addHandler(_ch)

--- a/src/deeprank_gnn/logger.py
+++ b/src/deeprank_gnn/logger.py
@@ -1,0 +1,11 @@
+import logging
+
+log = logging.getLogger("deeprank_gnn")
+log.setLevel(logging.DEBUG)
+
+_ch = logging.StreamHandler()
+_formatter = logging.Formatter(
+    " %(asctime)s %(module)s:%(lineno)d %(levelname)s - %(message)s"
+)
+_ch.setFormatter(_formatter)
+log.addHandler(_ch)

--- a/src/deeprank_gnn/main.py
+++ b/src/deeprank_gnn/main.py
@@ -21,6 +21,13 @@ def main():
     parser.add_argument(
         "--num_cores", type=int, default=1, help="Number of cores to use (default: 1)"
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory to save intermediate files in (default: a temporary "
+        "directory that is discarded after the run).",
+    )
     args = parser.parse_args()
 
     pdb_files = [Path(p) for p in args.pdb_files]
@@ -30,7 +37,7 @@ def main():
 
     num_cores = args.num_cores
 
-    workspace_path = setup_workspace()
+    workspace_path = setup_workspace(args.output_dir)
     structures_dir = workspace_path / "structures"
 
     pair_info: dict[str, tuple[str, str, str]] = {}
@@ -51,6 +58,9 @@ def main():
         ## (the GNN scores one interface at a time), with matching embeddings
         pair_info.update(pdb_input.write_chain_pairs(structures_dir, workspace_path))
 
+    if not pair_info:
+        parser.error("No chain pairs found: every input PDB has a single chain.")
+
     num_cores = min(num_cores, MAX_cores, len(pair_info))
     log.info(f"Using {num_cores} cores for processing")
 
@@ -66,7 +76,6 @@ def main():
     ## Present the results
     parse_output(
         csv_output=csv_output,
-        workspace_path=workspace_path,
         pair_info=pair_info,
     )
 

--- a/src/deeprank_gnn/main.py
+++ b/src/deeprank_gnn/main.py
@@ -1,0 +1,80 @@
+import argparse
+import shutil
+from pathlib import Path
+
+from deeprank_gnn.input import PDBInput
+from deeprank_gnn.logger import log
+from deeprank_gnn.predict import (
+    MAX_cores,
+    create_graph,
+    parse_output,
+    predict,
+    setup_workspace,
+)
+
+
+def main():
+    """Main function."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pdb_files", nargs="+", help="Path(s) to the PDB file(s).")
+    parser.add_argument(
+        "--num_cores", type=int, default=1, help="Number of cores to use (default: 1)"
+    )
+    args = parser.parse_args()
+
+    pdb_files = [Path(p) for p in args.pdb_files]
+    stems = [pdb_file.stem for pdb_file in pdb_files]
+    if len(set(stems)) != len(stems):
+        parser.error("Input PDB files must have unique names.")
+
+    num_cores = args.num_cores
+
+    workspace_path = setup_workspace()
+    structures_dir = workspace_path / "structures"
+
+    pair_info: dict[str, tuple[str, str, str]] = {}
+
+    for pdb_file in pdb_files:
+        # Copy PDB file to workspace
+        copied_pdb_file = workspace_path / pdb_file.name
+        shutil.copy(pdb_file, copied_pdb_file)
+
+        pdb_input = PDBInput.from_file(copied_pdb_file).renumber()
+
+        ## Generate embeddings (one ESM call per unique sequence) and materialize
+        ## one .pt file per model/chain label for graph generation
+        embeddings = pdb_input.gen_embeddings()
+        pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
+
+        ## Materialize one 2-chain PDB file per chain pair of each model
+        ## (the GNN scores one interface at a time), with matching embeddings
+        pair_info.update(pdb_input.write_chain_pairs(structures_dir, workspace_path))
+
+    num_cores = min(num_cores, MAX_cores, len(pair_info))
+    log.info(f"Using {num_cores} cores for processing")
+
+    ## Generate graph (one hdf5 covering every model of every input)
+    graph = create_graph(
+        pdb_path=structures_dir, workspace_path=workspace_path, nproc=num_cores
+    )
+    ## Predict fnat
+    csv_output = predict(
+        input_info=graph, workspace_path=workspace_path, ncores=num_cores
+    )
+
+    ## Present the results
+    parse_output(
+        csv_output=csv_output,
+        workspace_path=workspace_path,
+        pair_info=pair_info,
+    )
+
+    # Save the final prediction where the user invoked the command
+    result_file = Path.cwd() / Path(csv_output).name
+    shutil.copy(csv_output, result_file)
+    log.info(f"Result saved to {result_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deeprank_gnn/main.py
+++ b/src/deeprank_gnn/main.py
@@ -37,52 +37,58 @@ def main():
 
     num_cores = args.num_cores
 
+    is_temp_workspace = args.output_dir is None
     workspace_path = setup_workspace(args.output_dir)
     structures_dir = workspace_path / "structures"
 
-    pair_info: dict[str, tuple[str, str, str]] = {}
+    try:
+        pair_info: dict[str, tuple[str, str, str]] = {}
 
-    for pdb_file in pdb_files:
-        # Copy PDB file to workspace
-        copied_pdb_file = workspace_path / pdb_file.name
-        shutil.copy(pdb_file, copied_pdb_file)
+        for pdb_file in pdb_files:
+            # Copy PDB file to workspace
+            copied_pdb_file = workspace_path / pdb_file.name
+            if copied_pdb_file.resolve() != pdb_file.resolve():
+                shutil.copy(pdb_file, copied_pdb_file)
 
-        pdb_input = PDBInput.from_file(copied_pdb_file).renumber()
+            pdb_input = PDBInput.from_file(copied_pdb_file).renumber()
 
-        ## Generate embeddings (one ESM call per unique sequence) and materialize
-        ## one .pt file per model/chain label for graph generation
-        embeddings = pdb_input.gen_embeddings()
-        pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
+            ## Generate embeddings (one ESM call per unique sequence) and materialize
+            ## one .pt file per model/chain label for graph generation
+            embeddings = pdb_input.gen_embeddings()
+            pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
 
-        ## Materialize one 2-chain PDB file per chain pair of each model
-        ## (the GNN scores one interface at a time), with matching embeddings
-        pair_info.update(pdb_input.write_chain_pairs(structures_dir, workspace_path))
+            ## Materialize one 2-chain PDB file per chain pair of each model
+            ## (the GNN scores one interface at a time), with matching embeddings
+            pair_info.update(pdb_input.write_chain_pairs(structures_dir, workspace_path))
 
-    if not pair_info:
-        parser.error("No chain pairs found: every input PDB has a single chain.")
+        if not pair_info:
+            parser.error("No chain pairs found: every input PDB has a single chain.")
 
-    num_cores = min(num_cores, MAX_cores, len(pair_info))
-    log.info(f"Using {num_cores} cores for processing")
+        num_cores = min(num_cores, MAX_cores, len(pair_info))
+        log.info(f"Using {num_cores} cores for processing")
 
-    ## Generate graph (one hdf5 covering every model of every input)
-    graph = create_graph(
-        pdb_path=structures_dir, workspace_path=workspace_path, nproc=num_cores
-    )
-    ## Predict fnat
-    csv_output = predict(
-        input_info=graph, workspace_path=workspace_path, ncores=num_cores
-    )
+        ## Generate graph (one hdf5 covering every model of every input)
+        graph = create_graph(
+            pdb_path=structures_dir, workspace_path=workspace_path, nproc=num_cores
+        )
+        ## Predict fnat
+        csv_output = predict(
+            input_info=graph, workspace_path=workspace_path, ncores=num_cores
+        )
 
-    ## Present the results
-    parse_output(
-        csv_output=csv_output,
-        pair_info=pair_info,
-    )
+        ## Present the results
+        parse_output(
+            csv_output=csv_output,
+            pair_info=pair_info,
+        )
 
-    # Save the final prediction where the user invoked the command
-    result_file = Path.cwd() / Path(csv_output).name
-    shutil.copy(csv_output, result_file)
-    log.info(f"Result saved to {result_file}")
+        # Save the final prediction where the user invoked the command
+        result_file = Path.cwd() / Path(csv_output).name
+        shutil.copy(csv_output, result_file)
+        log.info(f"Result saved to {result_file}")
+    finally:
+        if is_temp_workspace:
+            shutil.rmtree(workspace_path, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/src/deeprank_gnn/main.py
+++ b/src/deeprank_gnn/main.py
@@ -11,6 +11,7 @@ from deeprank_gnn.predict import (
     predict,
     setup_workspace,
 )
+from deeprank_gnn.sequence import MultiFasta
 
 
 def main():
@@ -42,7 +43,8 @@ def main():
     structures_dir = workspace_path / "structures"
 
     try:
-        pair_info: dict[str, tuple[str, str, str]] = {}
+        pdb_inputs = []
+        combined_fasta = MultiFasta()
 
         for pdb_file in pdb_files:
             # Copy PDB file to workspace
@@ -52,9 +54,21 @@ def main():
 
             pdb_input = PDBInput.from_file(copied_pdb_file).renumber()
 
-            ## Generate embeddings (one ESM call per unique sequence) and materialize
-            ## one .pt file per model/chain label for graph generation
-            embeddings = pdb_input.gen_embeddings()
+            ## Collect this input's unique sequences into the shared pool, so
+            ## the ESM model is loaded and run once for every input PDB combined
+            for seq in pdb_input.to_multi_fasta().sequences.values():
+                combined_fasta.add(seq)
+
+            pdb_inputs.append(pdb_input)
+
+        ## Generate embeddings for every unique sequence across all inputs
+        ## (one ESM model load, one batch pass) and materialize one .pt file
+        ## per model/chain label for graph generation
+        embeddings = combined_fasta.gen_embeddings()
+
+        pair_info: dict[str, tuple[str, str, str]] = {}
+
+        for pdb_input in pdb_inputs:
             pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
 
             ## Materialize one 2-chain PDB file per chain pair of each model

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -12,6 +12,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 import torch
 
@@ -36,9 +37,19 @@ BATCH_SIZE = 64
 ###########################################################
 
 
-def setup_workspace() -> Path:
-    """Create a temporary directory (under the system temp dir) for storing intermediate files."""
-    workspace = Path(tempfile.mkdtemp())
+def setup_workspace(output_dir: Optional[Path] = None) -> Path:
+    """Create the workspace directory for storing intermediate files.
+
+    If output_dir is given, it's created (if needed) and used directly, so
+    intermediate files persist for inspection. Otherwise a temporary
+    directory under the system temp dir is used, and left for the OS to
+    clean up."""
+    if output_dir is not None:
+        workspace = Path(output_dir)
+        workspace.mkdir(parents=True, exist_ok=True)
+    else:
+        workspace = Path(tempfile.mkdtemp())
+
     log.info(f"Setting up workspace - {workspace}")
     return workspace
 
@@ -108,9 +119,7 @@ def convert_to_csv(hdf5_path: str) -> str:
     return csv_path
 
 
-def parse_output(
-    csv_output: str, workspace_path: Path, pair_info: dict[str, tuple[str, str, str]]
-) -> None:
+def parse_output(csv_output: str, pair_info: dict[str, tuple[str, str, str]]) -> None:
     """Parse the csv output and return the predicted fnat.
 
     pair_info maps each graph mol name (a "{pdb_id}_{chain_i}-{chain_j}" pair
@@ -131,7 +140,6 @@ def parse_output(
             )
             _data.append([pdb_id, chain_i, chain_j, predicted_fnat])
 
-    # output_fname = Path(workspace_path, "output.csv")
     with open(csv_output, "w") as f:
         f.write("pdb_id,chain_i,chain_j,predicted_fnat\n")
         for entry in _data:

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -171,7 +171,7 @@ def main():
 
     ## Generate embeddings (one ESM call per unique sequence) and materialize
     ## one .pt file per model/chain label for graph generation
-    embeddings = pdb_input.gen_embeddings(workspace_path)
+    embeddings = pdb_input.gen_embeddings()
     pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
 
     ## Materialize one single-model PDB file per model for graph generation

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -14,16 +14,13 @@ import os
 import re
 import shutil
 import tempfile
-from io import TextIOWrapper
 from pathlib import Path
-from typing import List
 
 import torch
-from Bio.PDB import PDBIO, Chain, Model, PDBParser, Structure
-from esm import FastaBatchedDataset, pretrained
 
 from deeprank_gnn.ginet import GINet
 from deeprank_gnn.GraphGenMP import GraphHDF5
+from deeprank_gnn.input import PDBInput
 from deeprank_gnn.NeuralNet import NeuralNet
 from deeprank_gnn.tools.hdf5_to_csv import hdf5_to_csv
 
@@ -38,8 +35,6 @@ ch.setFormatter(formatter)
 log.addHandler(ch)
 
 
-ESM_MODEL = "esm2_t33_650M_UR50D"
-
 spec = importlib.util.find_spec("deeprank_gnn")
 if spec and spec.origin:
     deeprank_gnn_path = os.path.dirname(spec.origin)
@@ -48,222 +43,17 @@ if spec and spec.origin:
         data_path, "treg_yfnat_b64_e20_lr0.001_foldall_esm.pth.tar"
     )
 
-TOKS_PER_BATCH = 4096
-REPR_LAYERS = [33]
-TRUNCATION_SEQ_LENGTH = 2500
-INCLUDE = ["mean", "per_tok"]
 MAX_cores = 50
 BATCH_SIZE = 64
-DEVICE_NAME = "cuda" if torch.cuda.is_available() else "cpu"  # configurable
 
 ###########################################################
 
 
-def setup_workspace(identificator: str) -> Path:
-    """Create a temporary directory for storing intermediate files."""
-    cwd = Path.cwd()
-    workspace = cwd / identificator
-
+def setup_workspace() -> Path:
+    """Create a temporary directory (under the system temp dir) for storing intermediate files."""
+    workspace = Path(tempfile.mkdtemp())
     log.info(f"Setting up workspace - {workspace}")
-    workspace.mkdir(parents=True, exist_ok=True)
-    # else:
-    #     log.info(f"WARNING: {workspace} already exists!")
     return workspace
-
-
-def renumber_pdb(pdb_file_path: Path, chain_ids: list) -> None:
-    """Renumber PDB file starting from 1 with no gaps."""
-    log.info(f"Renumbering PDB file.")
-
-    parser = PDBParser(QUIET=True)
-    structure = parser.get_structure("pdb_structure", pdb_file_path)
-
-    # Create a new structure with a new model
-    new_structure = Structure.Structure("renumbered_structure")
-    new_model = Model.Model(0)
-    new_structure.add(new_model)
-
-    # Get the chain IDs
-    new_chain_ids = ["A", "B"]
-
-    for index, chain_id in enumerate(chain_ids):
-        # Get the chain
-        chain = structure[0][chain_id]
-        chain.parent.detach_child(chain.id)
-
-        # Create a new chain with a new ID
-        new_chain = Chain.Chain(chain_id)
-
-        # Renumber residues in the chain starting from 1
-        residue_number = 1
-        for res in chain:
-            res = res.copy()
-            h, num, ins = res.id
-            res.id = (h, residue_number, ins)
-            new_chain.add(res)
-            residue_number += 1
-
-        # Add the new chain to the new model
-        new_chain.id = new_chain_ids[index]
-        new_model.add(new_chain)
-
-    # Save the modified structure to the same file path
-    with open(pdb_file_path, "w") as pdb_file:
-        io = PDBIO()
-        io.set_structure(new_structure)
-        io.save(pdb_file)
-
-
-def three_to_one() -> dict:
-    """three_to_one mapping of 20 standard amino acids."""
-    dict_ = {
-        "ALA": "A",
-        "ARG": "R",
-        "ASN": "N",
-        "ASP": "D",
-        "CYS": "C",
-        "GLN": "Q",
-        "GLU": "E",
-        "GLY": "G",
-        "HIS": "H",
-        "ILE": "I",
-        "LEU": "L",
-        "LYS": "K",
-        "MET": "M",
-        "PHE": "F",
-        "PRO": "P",
-        "SER": "S",
-        "THR": "T",
-        "TRP": "W",
-        "TYR": "Y",
-        "VAL": "V",
-    }
-
-    return dict_
-
-
-def pdb_to_fasta(pdb_file_path: Path, main_fasta_fh: TextIOWrapper) -> None:
-    """Convert a PDB file to a FASTA file."""
-    log.info(f"Reading sequence of PDB {pdb_file_path.name}")
-    parser = PDBParser()
-    structure = parser.get_structure("structure", pdb_file_path)
-
-    for chain_id in ["A", "B"]:
-        try:
-            chain = structure[0][chain_id]
-        except KeyError:
-            continue  # Chain might not be present
-
-        sequence = ""
-        modified_residue_count = 0  # Track modified residues
-
-        # Get the sequence of the chain
-        for residue in chain:
-            resname = residue.get_resname()
-            try:
-                res_dict = three_to_one()
-                sequence += res_dict[resname]
-            except KeyError:
-                sequence += "X"  # Unknown or modified residue
-                modified_residue_count += 1
-
-        # Add error/warning message if modified residues were found
-        if modified_residue_count > 0:
-            log.info(
-                f"{modified_residue_count} unrecognized residues found in chain {chain.id} "
-                f"of PDB {pdb_file_path.name}. Use DeepRank-GNN-esm with caution: non-standard residues are not officially supported."
-            )
-
-        # Write the sequence to a FASTA file
-        root = re.findall(r"(.*).pdb", pdb_file_path.name)[0]
-        main_fasta_fh.write(f">{root}.{chain.id}\n{sequence}\n")
-
-
-# Helper function to process each batch
-def process_batch(labels, strs, output_dir, representations):
-    embedd_path = []
-    for i, label in enumerate(labels):
-        result = {"label": label}
-        truncate_len = min(TRUNCATION_SEQ_LENGTH, len(strs[i]))
-
-        # Add representations
-        if "per_tok" in INCLUDE:
-            result["representations"] = {
-                layer: t[i, 1 : truncate_len + 1].clone()
-                for layer, t in representations.items()
-            }
-
-        # Add mean representations
-        if "mean" in INCLUDE:
-            result["mean_representations"] = {
-                layer: t[i, 1 : truncate_len + 1].mean(0).clone()
-                for layer, t in representations.items()
-            }
-
-        # Save the result to file
-        output_file = output_dir / f"{label}.pt"
-        torch.save(result, output_file)
-        embedd_path.append(output_file)
-    return embedd_path
-
-
-# Helper function to get the model output
-def get_model_output(toks, model, repr_layers):
-    out = model(toks, repr_layers=repr_layers, return_contacts="contacts" in INCLUDE)
-    representations = {layer: t.cpu() for layer, t in out["representations"].items()}
-    return representations
-
-
-# Main function
-def get_embedding(fasta_file: Path, output_dir: Path) -> List[Path]:
-    """Generate protein sequence embeddings."""
-    log.info("Generating embedding for protein sequence.")
-    log.info("#" * 80)
-
-    model, alphabet = pretrained.load_model_and_alphabet(ESM_MODEL)
-    model.eval()
-
-    if torch.cuda.is_available():
-        model = model.cuda()
-
-    # Prepare dataset and data loader
-    dataset = FastaBatchedDataset.from_file(fasta_file)
-    batches = dataset.get_batch_indices(TOKS_PER_BATCH, extra_toks_per_seq=1)
-    data_loader = torch.utils.data.DataLoader(
-        dataset,
-        collate_fn=alphabet.get_batch_converter(TRUNCATION_SEQ_LENGTH),
-        batch_sampler=batches,
-    )
-
-    # Create output directory
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # Define representation layers
-    repr_layers = [
-        (i + model.num_layers + 1) % (model.num_layers + 1) for i in REPR_LAYERS
-    ]
-
-    embedd_path = []
-    with torch.no_grad():
-        for _, (labels, strs, toks) in enumerate(data_loader):
-            if torch.cuda.is_available():
-                toks = toks.to("cuda", non_blocking=True)
-
-            # Get model output and representations
-            representations = get_model_output(toks, model, repr_layers)
-
-            # Process the batch
-            embedd_path.extend(
-                process_batch(
-                    labels,
-                    strs,
-                    output_dir,
-                    representations,
-                )
-            )
-
-    log.info("#" * 80)
-    return embedd_path
 
 
 def create_graph(pdb_path: Path, workspace_path: Path, nproc: int) -> str:
@@ -357,85 +147,40 @@ def parse_output(csv_output: str, workspace_path: Path, chain_ids: list) -> None
     log.info(f"Output written to {csv_output}")
 
 
-def split_input_pdb(pdb_file: Path) -> list[Path]:
-    """Saves PDB models in a split folder, handling both single and multiple models."""
-    parser = PDBParser(QUIET=True)
-    structure = parser.get_structure("structure", pdb_file)
-
-    output_dir = pdb_file.parent / f"{pdb_file.stem}_split"
-    output_dir.mkdir(exist_ok=True)
-
-    saved_files = []
-    io = PDBIO()
-
-    # Check if the PDB contains multiple models
-    is_ensemble = len(list(structure)) > 1
-
-    for model in structure:
-        model_id = model.id if is_ensemble else 0  # Use 0 for single structure
-        output_file = output_dir / f"{pdb_file.stem}_model_{model_id}.pdb"
-        io.set_structure(model)
-        io.save(str(output_file))
-        saved_files.append(Path(output_file))
-
-    log.info(f"Processed {len(saved_files)} model(s) from {pdb_file.name}")
-    return saved_files
-
-
 def main():
     """Main function."""
 
     parser = argparse.ArgumentParser()
     parser.add_argument("pdb_file", help="Path to the PDB file.")
-    parser.add_argument("chain_id_1", help="First chain ID.")
-    parser.add_argument("chain_id_2", help="Second chain ID.")
     parser.add_argument("num_cores", type=int, help="Number of cores to use")
     args = parser.parse_args()
 
     pdb_file = args.pdb_file
-    chain_id_1 = args.chain_id_1
-    chain_id_2 = args.chain_id_2
     num_cores = args.num_cores
 
-    identificator = Path(pdb_file).stem + f"-gnn_esm_pred_{chain_id_1}_{chain_id_2}"
-    workspace_path = setup_workspace(identificator)
+    workspace_path = setup_workspace()
 
     # Copy PDB file to workspace
     src = Path(pdb_file)
     copied_pdb_file = Path(workspace_path) / Path(pdb_file).name
     shutil.copy(src, copied_pdb_file)
 
-    pdb_files = split_input_pdb(copied_pdb_file)
-    num_cores = min(num_cores, MAX_cores, len(pdb_files))
+    pdb_input = PDBInput.from_file(copied_pdb_file).renumber()
+    num_cores = min(num_cores, MAX_cores, len(pdb_input.models))
     log.info(f"Using {num_cores} cores for processing")
 
-    embeds = []
+    ## Generate embeddings (one ESM call per unique sequence) and materialize
+    ## one .pt file per model/chain label for graph generation
+    embeddings = pdb_input.gen_embeddings(workspace_path)
+    pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
 
-    for pdb_file in pdb_files:
-        ## Renumber PDB first!
-        renumber_pdb(pdb_file_path=pdb_file, chain_ids=[chain_id_1, chain_id_2])
-
-    ## PDB to FASTA (after renumbering)
-    fasta_f = Path(workspace_path) / (pdb_files[0].stem + ".fasta")
-    with open(fasta_f, "w") as f:
-        pdb_to_fasta(pdb_file_path=Path(pdb_files[0]), main_fasta_fh=f)
-
-    ## Generate embeddings
-    embed_paths = get_embedding(fasta_file=fasta_f, output_dir=workspace_path)
-
-    for pdb_file in pdb_files:
-        # For pdbs that were not used in embedding cal, copy the embed and rename
-        if pdb_file != pdb_files[0]:
-            for embed_chain in embed_paths:
-                pdb_name = pdb_file.stem
-                new_stem = pdb_name + embed_chain.stem[embed_chain.stem.find(".") :]
-                dst = embed_chain.with_name(new_stem + embed_chain.suffix)
-                shutil.copy(embed_chain, dst)
-                embeds.append(dst)
+    ## Materialize one single-model PDB file per model for graph generation
+    structures_dir = workspace_path / "structures"
+    pdb_input.write_models(structures_dir)
 
     ## Generate graph
     graph = create_graph(
-        pdb_path=pdb_file.parent, workspace_path=workspace_path, nproc=num_cores
+        pdb_path=structures_dir, workspace_path=workspace_path, nproc=num_cores
     )
     ## Predict fnat
     csv_output = predict(
@@ -443,15 +188,17 @@ def main():
     )
 
     ## Present the results
+    chain_ids = sorted({chain.id for model in pdb_input.models for chain in model})
     parse_output(
         csv_output=csv_output,
         workspace_path=workspace_path,
-        chain_ids=[chain_id_1, chain_id_2],
+        chain_ids=chain_ids,
     )
 
-    # Clean copied embeddings
-    for embed in embeds:
-        embed.unlink()
+    # Save the final prediction where the user invoked the command
+    result_file = Path.cwd() / Path(csv_output).name
+    shutil.copy(csv_output, result_file)
+    log.info(f"Result saved to {result_file}")
 
 
 if __name__ == "__main__":

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -120,7 +120,8 @@ def convert_to_csv(hdf5_path: str) -> str:
 
 
 def parse_output(csv_output: str, pair_info: dict[str, tuple[str, str, str]]) -> None:
-    """Parse the csv output and return the predicted fnat.
+    """Rewrite csv_output in place with pdb_id/chain_i/chain_j/predicted_fnat
+    columns, replacing the raw mol/prediction columns written by convert_to_csv.
 
     pair_info maps each graph mol name (a "{pdb_id}_{chain_i}-{chain_j}" pair
     root) to its (pdb_id, chain_i, chain_j).

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -7,12 +7,9 @@ from Bio import BiopythonWarning
 warnings.filterwarnings("ignore", category=BiopythonWarning)
 warnings.filterwarnings("ignore", message=".*deprecated.*")
 
-import argparse
 import importlib.util
-import logging
 import os
 import re
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -20,19 +17,9 @@ import torch
 
 from deeprank_gnn.ginet import GINet
 from deeprank_gnn.GraphGenMP import GraphHDF5
-from deeprank_gnn.input import PDBInput
+from deeprank_gnn.logger import log
 from deeprank_gnn.NeuralNet import NeuralNet
 from deeprank_gnn.tools.hdf5_to_csv import hdf5_to_csv
-
-# Configure logging
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-formatter = logging.Formatter(
-    " %(asctime)s %(module)s:%(lineno)d %(levelname)s - %(message)s"
-)
-ch.setFormatter(formatter)
-log.addHandler(ch)
 
 
 spec = importlib.util.find_spec("deeprank_gnn")
@@ -121,8 +108,14 @@ def convert_to_csv(hdf5_path: str) -> str:
     return csv_path
 
 
-def parse_output(csv_output: str, workspace_path: Path, chain_ids: list) -> None:
-    """Parse the csv output and return the predicted fnat."""
+def parse_output(
+    csv_output: str, workspace_path: Path, pair_info: dict[str, tuple[str, str, str]]
+) -> None:
+    """Parse the csv output and return the predicted fnat.
+
+    pair_info maps each graph mol name (a "{pdb_id}_{chain_i}-{chain_j}" pair
+    root) to its (pdb_id, chain_i, chain_j).
+    """
     _data = []
     with open(csv_output, "r") as f:
         for line in f.readlines():
@@ -130,76 +123,19 @@ def parse_output(csv_output: str, workspace_path: Path, chain_ids: list) -> None
                 # this is a header
                 continue
             data = line.split(",")
-            pdb_id = re.findall(r"b'(.*)'", str(data[3]))[0]
+            mol = re.findall(r"b'(.*)'", str(data[3]))[0]
             predicted_fnat = float(data[5])
+            pdb_id, chain_i, chain_j = pair_info.get(mol, (mol, "?", "?"))
             log.info(
-                f"Predicted fnat for {pdb_id} between chain{chain_ids[0]} and chain{chain_ids[1]}: {predicted_fnat:.3f}"
+                f"Predicted fnat for {pdb_id} between chain{chain_i} and chain{chain_j}: {predicted_fnat:.3f}"
             )
-            _data.append([pdb_id, predicted_fnat])
+            _data.append([pdb_id, chain_i, chain_j, predicted_fnat])
 
     # output_fname = Path(workspace_path, "output.csv")
     with open(csv_output, "w") as f:
-        f.write("pdb_id,predicted_fnat\n")
+        f.write("pdb_id,chain_i,chain_j,predicted_fnat\n")
         for entry in _data:
-            pdb, fnat = entry
-            f.write(f"{pdb},{fnat:.3f}\n")
+            pdb_id, chain_i, chain_j, fnat = entry
+            f.write(f"{pdb_id},{chain_i},{chain_j},{fnat:.3f}\n")
 
     log.info(f"Output written to {csv_output}")
-
-
-def main():
-    """Main function."""
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("pdb_file", help="Path to the PDB file.")
-    parser.add_argument("num_cores", type=int, help="Number of cores to use")
-    args = parser.parse_args()
-
-    pdb_file = args.pdb_file
-    num_cores = args.num_cores
-
-    workspace_path = setup_workspace()
-
-    # Copy PDB file to workspace
-    src = Path(pdb_file)
-    copied_pdb_file = Path(workspace_path) / Path(pdb_file).name
-    shutil.copy(src, copied_pdb_file)
-
-    pdb_input = PDBInput.from_file(copied_pdb_file).renumber()
-    num_cores = min(num_cores, MAX_cores, len(pdb_input.models))
-    log.info(f"Using {num_cores} cores for processing")
-
-    ## Generate embeddings (one ESM call per unique sequence) and materialize
-    ## one .pt file per model/chain label for graph generation
-    embeddings = pdb_input.gen_embeddings()
-    pdb_input.write_embeddings(embeddings, output_dir=workspace_path)
-
-    ## Materialize one single-model PDB file per model for graph generation
-    structures_dir = workspace_path / "structures"
-    pdb_input.write_models(structures_dir)
-
-    ## Generate graph
-    graph = create_graph(
-        pdb_path=structures_dir, workspace_path=workspace_path, nproc=num_cores
-    )
-    ## Predict fnat
-    csv_output = predict(
-        input_info=graph, workspace_path=workspace_path, ncores=num_cores
-    )
-
-    ## Present the results
-    chain_ids = sorted({chain.id for model in pdb_input.models for chain in model})
-    parse_output(
-        csv_output=csv_output,
-        workspace_path=workspace_path,
-        chain_ids=chain_ids,
-    )
-
-    # Save the final prediction where the user invoked the command
-    result_file = Path.cwd() / Path(csv_output).name
-    shutil.copy(csv_output, result_file)
-    log.info(f"Result saved to {result_file}")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -132,11 +132,12 @@ def parse_output(csv_output: str, pair_info: dict[str, tuple[str, str, str]]) ->
                 # this is a header
                 continue
             data = line.split(",")
-            mol = re.findall(r"b'(.*)'", str(data[3]))[0]
+            match = re.findall(r"b'(.*)'", str(data[3]))
+            mol = match[0] if match else str(data[3]).strip()
             predicted_fnat = float(data[5])
             pdb_id, chain_i, chain_j = pair_info.get(mol, (mol, "?", "?"))
             log.info(
-                f"Predicted fnat for {pdb_id} between chain{chain_i} and chain{chain_j}: {predicted_fnat:.3f}"
+                f"Predicted fnat for {pdb_id} between chain {chain_i} and chain {chain_j}: {predicted_fnat:.3f}"
             )
             _data.append([pdb_id, chain_i, chain_j, predicted_fnat])
 

--- a/src/deeprank_gnn/predict.py
+++ b/src/deeprank_gnn/predict.py
@@ -127,6 +127,7 @@ def parse_output(csv_output: str, pair_info: dict[str, tuple[str, str, str]]) ->
     root) to its (pdb_id, chain_i, chain_j).
     """
     _data = []
+    model_totals: dict[str, float] = {}
     with open(csv_output, "r") as f:
         for line in f.readlines():
             if line.startswith(","):
@@ -141,6 +142,7 @@ def parse_output(csv_output: str, pair_info: dict[str, tuple[str, str, str]]) ->
                 f"Predicted fnat for {pdb_id} between chain {chain_i} and chain {chain_j}: {predicted_fnat:.3f}"
             )
             _data.append([pdb_id, chain_i, chain_j, predicted_fnat])
+            model_totals[pdb_id] = model_totals.get(pdb_id, 0.0) + predicted_fnat
 
     with open(csv_output, "w") as f:
         f.write("pdb_id,chain_i,chain_j,predicted_fnat\n")
@@ -149,3 +151,11 @@ def parse_output(csv_output: str, pair_info: dict[str, tuple[str, str, str]]) ->
             f.write(f"{pdb_id},{chain_i},{chain_j},{fnat:.3f}\n")
 
     log.info(f"Output written to {csv_output}")
+
+    summary_csv = str(csv_output).replace(".csv", "_summary.csv")
+    with open(summary_csv, "w") as f:
+        f.write("pdb_id,combined_fnat\n")
+        for pdb_id, total_fnat in model_totals.items():
+            f.write(f"{pdb_id},{total_fnat:.3f}\n")
+
+    log.info(f"Summary output written to {summary_csv}")

--- a/src/deeprank_gnn/sequence.py
+++ b/src/deeprank_gnn/sequence.py
@@ -1,0 +1,123 @@
+"""Sequence and MultiFasta: labeled amino-acid sequences and the deduped
+multi-FASTA/ESM-embedding pipeline built from them."""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+from esm import FastaBatchedDataset, pretrained
+
+log = logging.getLogger(__name__)
+
+ESM_MODEL = "esm2_t33_650M_UR50D"
+TOKS_PER_BATCH = 4096
+REPR_LAYERS = [33]
+TRUNCATION_SEQ_LENGTH = 2500
+
+
+@dataclass
+class Sequence:
+    label: str
+    sequence: str
+
+    @property
+    def modified_residue_count(self) -> int:
+        return self.sequence.count("X")
+
+
+@dataclass
+class MultiFasta:
+    """A deduped collection of Sequences: identical sequences (e.g. homodimer
+    chains, repeats across ensemble models) are kept once, with every label
+    mapped to the canonical label actually written/embedded."""
+
+    label_map: dict[str, str] = field(
+        default_factory=dict
+    )  # every label -> canonical label
+    sequences: dict[str, Sequence] = field(
+        default_factory=dict
+    )  # canonical label -> Sequence
+    _seq_to_canonical_label: dict[str, str] = field(default_factory=dict, repr=False)
+
+    def add(self, seq: Sequence) -> None:
+        if seq.sequence in self._seq_to_canonical_label:
+            self.label_map[seq.label] = self._seq_to_canonical_label[seq.sequence]
+        else:
+            self._seq_to_canonical_label[seq.sequence] = seq.label
+            self.label_map[seq.label] = seq.label
+            self.sequences[seq.label] = seq
+
+    def gen_embeddings(self) -> list[tuple[str, torch.Tensor]]:
+        """Generate ESM embeddings for every unique sequence in this MultiFasta.
+
+        Runs ESM once over the in-memory sequences and returns one
+        (sequence, embedding) pair per unique sequence - one ESM call per
+        unique sequence, not per label.
+        """
+        log.info(f"Generating embeddings for {len(self.sequences)} unique sequence(s).")
+
+        model, alphabet = pretrained.load_model_and_alphabet(ESM_MODEL)
+        model.eval()
+        if torch.cuda.is_available():
+            model = model.cuda()
+
+        labels = list(self.sequences.keys())
+        seqs = [seq.sequence for seq in self.sequences.values()]
+        dataset = FastaBatchedDataset(labels, seqs)
+        batches = dataset.get_batch_indices(TOKS_PER_BATCH, extra_toks_per_seq=1)
+        data_loader = torch.utils.data.DataLoader(
+            dataset,
+            collate_fn=alphabet.get_batch_converter(TRUNCATION_SEQ_LENGTH),
+            batch_sampler=batches,
+        )
+
+        repr_layers = [
+            (i + model.num_layers + 1) % (model.num_layers + 1) for i in REPR_LAYERS
+        ]
+        last_layer = repr_layers[-1]
+
+        results: list[tuple[str, torch.Tensor]] = []
+        with torch.no_grad():
+            for labels, strs, toks in data_loader:
+                if torch.cuda.is_available():
+                    toks = toks.to("cuda", non_blocking=True)
+
+                out = model(toks, repr_layers=repr_layers, return_contacts=False)
+                representations = {
+                    layer: t.cpu() for layer, t in out["representations"].items()
+                }
+
+                for i, label in enumerate(labels):
+                    truncate_len = min(TRUNCATION_SEQ_LENGTH, len(strs[i]))
+                    embedding = representations[last_layer][
+                        i, 1 : truncate_len + 1
+                    ].clone()
+                    results.append((self.sequences[label].sequence, embedding))
+
+        return results
+
+    def write_embeddings(
+        self, embeddings: list[tuple[str, torch.Tensor]], output_dir: Path
+    ) -> list[Path]:
+        """Persist gen_embeddings() output as one {label}.pt file per label -
+        including labels whose sequence was deduplicated away - matching the
+        naming GraphGenMP._add_embedding expects on disk."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        seq_to_embedding = {sequence: embedding for sequence, embedding in embeddings}
+
+        saved_files = []
+        for label, canonical_label in self.label_map.items():
+            sequence = self.sequences[canonical_label].sequence
+            embedding = seq_to_embedding[sequence]
+
+            output_file = output_dir / f"{label}.pt"
+            torch.save(
+                {"label": label, "representations": {REPR_LAYERS[-1]: embedding}},
+                output_file,
+            )
+            saved_files.append(output_file)
+
+        log.info(f"Wrote {len(saved_files)} embedding file(s) to {output_dir}")
+        return saved_files

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,0 +1,194 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import torch
+from Bio.Data.PDBData import protein_letters_1to3
+from Bio.PDB import PDBIO, Atom, Chain, Model, Residue, Structure
+
+from deeprank_gnn.input import PDBInput
+
+
+def _make_chain(chain_id: str, seq: str) -> Chain.Chain:
+    chain = Chain.Chain(chain_id)
+    for i, aa in enumerate(seq, start=1):
+        resname = protein_letters_1to3[aa].upper()
+        residue = Residue.Residue((" ", i, " "), resname, "")
+        atom = Atom.Atom(
+            "CA", np.array([float(i), 0.0, 0.0]), 20.0, 1.0, " ", "CA", i, "C"
+        )
+        residue.add(atom)
+        chain.add(residue)
+    return chain
+
+
+def _make_structure(models: list) -> Structure.Structure:
+    """models: list of {chain_id: sequence} dicts, one per model."""
+    structure = Structure.Structure("synthetic")
+    for model_id, chains in enumerate(models):
+        model = Model.Model(model_id)
+        for chain_id, seq in chains.items():
+            model.add(_make_chain(chain_id, seq))
+        structure.add(model)
+    return structure
+
+
+class TestPDBInputSingleModel(unittest.TestCase):
+    def setUp(self):
+        self.structure = _make_structure([{"A": "MKTAYI", "B": "GGCLVK"}])
+        self.pdb_input = PDBInput(self.structure, name="synth")
+
+    def test_is_ensemble_false_for_single_model(self):
+        self.assertFalse(self.pdb_input.is_ensemble)
+
+    def test_model_name_has_no_model_suffix(self):
+        model = self.pdb_input.models[0]
+        self.assertEqual(self.pdb_input.model_name(model), "synth")
+
+    def test_chain_pairs_two_chains(self):
+        model = self.pdb_input.models[0]
+        self.assertEqual(self.pdb_input.chain_pairs(model), [("A", "B")])
+
+    def test_pair_name(self):
+        model = self.pdb_input.models[0]
+        self.assertEqual(self.pdb_input.pair_name(model, "A", "B"), "synth_A-B")
+
+
+class TestPDBInputEnsemble(unittest.TestCase):
+    def setUp(self):
+        self.structure = _make_structure(
+            [{"A": "MKTAYI", "B": "GGCLVK"}, {"A": "MKTAYI", "B": "GGCLVK"}]
+        )
+        self.pdb_input = PDBInput(self.structure, name="synth")
+
+    def test_is_ensemble_true_for_multiple_models(self):
+        self.assertTrue(self.pdb_input.is_ensemble)
+
+    def test_model_name_has_model_suffix(self):
+        model0, model1 = self.pdb_input.models
+        self.assertEqual(self.pdb_input.model_name(model0), "synth_model0")
+        self.assertEqual(self.pdb_input.model_name(model1), "synth_model1")
+
+
+class TestRenumber(unittest.TestCase):
+    def test_renumber_closes_gaps(self):
+        structure = _make_structure([{"A": "MKTAYI"}])
+        # Introduce gaps/non-sequential numbering in the original residue ids
+        chain = list(structure[0])[0]
+        for offset, residue in enumerate(list(chain)):
+            h, _, ins = residue.id
+            residue.id = (h, 100 + offset * 5, ins)
+
+        pdb_input = PDBInput(structure, name="synth").renumber()
+
+        chain = list(pdb_input.models[0])[0]
+        residue_numbers = [res.id[1] for res in chain]
+        self.assertEqual(residue_numbers, list(range(1, len(residue_numbers) + 1)))
+
+
+class TestToMultiFasta(unittest.TestCase):
+    def test_identical_sequences_are_deduped(self):
+        # Homodimer: chains A and B share the same sequence
+        structure = _make_structure([{"A": "MKTAYI", "B": "MKTAYI"}])
+        pdb_input = PDBInput(structure, name="synth")
+
+        multi_fasta = pdb_input.to_multi_fasta()
+
+        self.assertEqual(len(multi_fasta.sequences), 1)
+        self.assertEqual(
+            multi_fasta.label_map["synth.A"], multi_fasta.label_map["synth.B"]
+        )
+
+    def test_distinct_sequences_are_kept_separate(self):
+        structure = _make_structure([{"A": "MKTAYI", "B": "GGCLVK"}])
+        pdb_input = PDBInput(structure, name="synth")
+
+        multi_fasta = pdb_input.to_multi_fasta()
+
+        self.assertEqual(len(multi_fasta.sequences), 2)
+        self.assertNotEqual(
+            multi_fasta.label_map["synth.A"], multi_fasta.label_map["synth.B"]
+        )
+
+
+class TestWriteChainPairs(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.tmp_path = Path(self.tmpdir.name)
+
+        self.structure = _make_structure(
+            [{"A": "MKTAYI", "B": "GGCLVK", "C": "PPQRST"}]
+        )
+        self.pdb_input = PDBInput(self.structure, name="synth")
+
+        # Fake per-chain embeddings, standing in for write_embeddings() output
+        self.embedding_dir = self.tmp_path / "embeddings"
+        self.embedding_dir.mkdir()
+        self.chain_tensors = {}
+        for chain_id in ("A", "B", "C"):
+            tensor = torch.rand(6, 4)
+            self.chain_tensors[chain_id] = tensor
+            torch.save(
+                {"label": f"synth.{chain_id}", "representations": {33: tensor}},
+                self.embedding_dir / f"synth.{chain_id}.pt",
+            )
+
+        self.pdb_dir = self.tmp_path / "structures"
+        self.pair_info = self.pdb_input.write_chain_pairs(
+            self.pdb_dir, self.embedding_dir
+        )
+
+    def test_one_pdb_file_per_chain_pair(self):
+        expected_roots = {"synth_A-B", "synth_A-C", "synth_B-C"}
+        written = {p.stem for p in self.pdb_dir.glob("*.pdb")}
+        self.assertEqual(written, expected_roots)
+
+    def test_pair_info_keeps_original_chain_ids(self):
+        self.assertEqual(self.pair_info["synth_A-B"], ("synth", "A", "B"))
+        self.assertEqual(self.pair_info["synth_A-C"], ("synth", "A", "C"))
+        self.assertEqual(self.pair_info["synth_B-C"], ("synth", "B", "C"))
+
+    def test_written_pdb_chains_are_relabeled_to_A_and_B(self):
+        from Bio.PDB import PDBParser
+
+        parser = PDBParser(QUIET=True)
+        for root in ("synth_A-B", "synth_A-C", "synth_B-C"):
+            structure = parser.get_structure(root, self.pdb_dir / f"{root}.pdb")
+            chain_ids = {chain.id for chain in structure[0]}
+            self.assertEqual(chain_ids, {"A", "B"})
+
+    def test_embedding_files_copied_under_relabeled_names(self):
+        # synth_A-C pairs original chain A (-> A) with original chain C (-> B)
+        pt_a = torch.load(self.embedding_dir / "synth_A-C.A.pt")
+        pt_b = torch.load(self.embedding_dir / "synth_A-C.B.pt")
+        self.assertTrue(
+            torch.equal(pt_a["representations"][33], self.chain_tensors["A"])
+        )
+        self.assertTrue(
+            torch.equal(pt_b["representations"][33], self.chain_tensors["C"])
+        )
+
+
+class TestPDBInputFromFile(unittest.TestCase):
+    def test_from_file_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            structure = _make_structure([{"A": "MKTAYI", "B": "GGCLVK"}])
+
+            pdb_file = tmp_path / "synth.pdb"
+            io = PDBIO()
+            io.set_structure(structure)
+            io.save(str(pdb_file))
+
+            pdb_input = PDBInput.from_file(pdb_file)
+
+            self.assertEqual(pdb_input.name, "synth")
+            self.assertEqual(len(pdb_input.models), 1)
+            chain_ids = {chain.id for chain in pdb_input.models[0]}
+            self.assertEqual(chain_ids, {"A", "B"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_e2e.py
+++ b/tests/test_main_e2e.py
@@ -1,0 +1,73 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+
+CWD = Path(__file__).resolve().parent
+PDB_1ATN_1W = CWD / "data" / "pdb" / "1ATN" / "1ATN_1w.pdb"
+PDB_1ATN_2W = CWD / "data" / "pdb" / "1ATN" / "1ATN_2w.pdb"
+
+EXPECTED_ROWS = {
+    ("1ATN_1w", "A", "B"): 0.021,
+    ("1ATN_2w", "A", "B"): 0.008,
+}
+
+
+@pytest.mark.e2e
+class TestMainEndToEnd(unittest.TestCase):
+    """Runs the real CLI (ESM embeddings, graph generation, GNN inference)
+    end to end on multiple input files and checks the predicted fnat per
+    chain pair against known values."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.TemporaryDirectory()
+        tmp_path = Path(cls.tmpdir.name)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "deeprank_gnn.main",
+                str(PDB_1ATN_1W),
+                str(PDB_1ATN_2W),
+            ],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        cls.result = result
+
+        csv_output = tmp_path / "GNN_esm_prediction.csv"
+        cls.rows = (
+            csv_output.read_text().strip().splitlines() if csv_output.exists() else []
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpdir.cleanup()
+
+    def test_exits_successfully(self):
+        self.assertEqual(self.result.returncode, 0, self.result.stderr)
+
+    def test_output_has_expected_header(self):
+        self.assertTrue(self.rows, "no output CSV produced")
+        self.assertEqual(self.rows[0], "pdb_id,chain_i,chain_j,predicted_fnat")
+
+    def test_every_expected_pair_is_predicted_within_tolerance(self):
+        actual = {}
+        for row in self.rows[1:]:
+            pdb_id, chain_i, chain_j, fnat = row.split(",")
+            actual[(pdb_id, chain_i, chain_j)] = float(fnat)
+
+        self.assertEqual(set(actual), set(EXPECTED_ROWS))
+        for key, expected_fnat in EXPECTED_ROWS.items():
+            self.assertAlmostEqual(actual[key], expected_fnat, places=2, msg=key)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -26,7 +26,6 @@ class TestParseOutput(unittest.TestCase):
 
             parse_output(
                 csv_output=str(csv_output),
-                workspace_path=Path(tmpdir),
                 pair_info=pair_info,
             )
 
@@ -51,9 +50,7 @@ class TestParseOutput(unittest.TestCase):
             csv_output = Path(tmpdir) / "result.csv"
             csv_output.write_text(raw_csv)
 
-            parse_output(
-                csv_output=str(csv_output), workspace_path=Path(tmpdir), pair_info={}
-            )
+            parse_output(csv_output=str(csv_output), pair_info={})
 
             lines = csv_output.read_text().splitlines()
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -2,39 +2,62 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import torch
-
-from deeprank_gnn.predict import get_embedding
+from deeprank_gnn.predict import parse_output
 
 
-class TestPredict(unittest.TestCase):
-    def test_get_embedding(self):
-        """Test that get_embedding generates embeddings correctly."""
-        # Create a temporary directory for test files
+class TestParseOutput(unittest.TestCase):
+    def test_rewrites_csv_with_chain_columns(self):
+        raw_csv = (
+            ",epoch,set,model,targets,prediction\n"
+            "0,0,test,b'1qu9_ABC_A-B',n,0.488\n"
+            "1,0,test,b'1qu9_ABC_A-C',n,0.484\n"
+            ",epoch,set,model,targets,prediction\n"
+            "0,0,test,b'2oob_A-B',n,0.792\n"
+        )
+        pair_info = {
+            "1qu9_ABC_A-B": ("1qu9_ABC", "A", "B"),
+            "1qu9_ABC_A-C": ("1qu9_ABC", "A", "C"),
+            "2oob_A-B": ("2oob", "A", "B"),
+        }
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            tmpdir = Path(tmpdir)
+            csv_output = Path(tmpdir) / "result.csv"
+            csv_output.write_text(raw_csv)
 
-            # Create a simple fasta file with a short sequence
-            fasta_file = tmpdir / "test.fasta"
-            fasta_file.write_text(">test_seq.A\nMKTAYIAKQRQISFVKSHFSRQLE\n")
+            parse_output(
+                csv_output=str(csv_output),
+                workspace_path=Path(tmpdir),
+                pair_info=pair_info,
+            )
 
-            # Create output directory
-            output_dir = tmpdir / "embeddings"
+            lines = csv_output.read_text().splitlines()
 
-            # Generate embeddings
-            embed_paths = get_embedding(fasta_file, output_dir)
+        self.assertEqual(lines[0], "pdb_id,chain_i,chain_j,predicted_fnat")
+        self.assertEqual(
+            lines[1:],
+            [
+                "1qu9_ABC,A,B,0.488",
+                "1qu9_ABC,A,C,0.484",
+                "2oob,A,B,0.792",
+            ],
+        )
 
-            # Verify output
-            self.assertEqual(len(embed_paths), 1)
-            self.assertTrue(embed_paths[0].exists())
-            self.assertTrue(str(embed_paths[0]).endswith(".pt"))
+    def test_unknown_mol_falls_back_to_placeholder_chains(self):
+        raw_csv = (
+            ",epoch,set,model,targets,prediction\n0,0,test,b'unknown_mol',n,0.100\n"
+        )
 
-            # Load and verify the embedding file
-            result = torch.load(embed_paths[0])
-            self.assertIn("label", result)
-            self.assertIn("representations", result)
-            self.assertIn("mean_representations", result)
-            self.assertEqual(result["label"], "test_seq.A")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_output = Path(tmpdir) / "result.csv"
+            csv_output.write_text(raw_csv)
+
+            parse_output(
+                csv_output=str(csv_output), workspace_path=Path(tmpdir), pair_info={}
+            )
+
+            lines = csv_output.read_text().splitlines()
+
+        self.assertEqual(lines[1], "unknown_mol,?,?,0.100")
 
 
 if __name__ == "__main__":

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,71 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+from deeprank_gnn.sequence import MultiFasta, Sequence
+
+
+class TestSequence(unittest.TestCase):
+    def test_modified_residue_count(self):
+        seq = Sequence(label="a", sequence="MKXTAXYI")
+        self.assertEqual(seq.modified_residue_count, 2)
+
+    def test_modified_residue_count_zero(self):
+        seq = Sequence(label="a", sequence="MKTAYI")
+        self.assertEqual(seq.modified_residue_count, 0)
+
+
+class TestMultiFastaAdd(unittest.TestCase):
+    def test_identical_sequences_are_deduped(self):
+        multi_fasta = MultiFasta()
+        multi_fasta.add(Sequence(label="root.A", sequence="MKTAYI"))
+        multi_fasta.add(Sequence(label="root.B", sequence="MKTAYI"))
+
+        self.assertEqual(len(multi_fasta.sequences), 1)
+        self.assertEqual(
+            multi_fasta.label_map["root.A"], multi_fasta.label_map["root.B"]
+        )
+        self.assertEqual(multi_fasta.label_map["root.A"], "root.A")
+
+    def test_distinct_sequences_are_kept(self):
+        multi_fasta = MultiFasta()
+        multi_fasta.add(Sequence(label="root.A", sequence="MKTAYI"))
+        multi_fasta.add(Sequence(label="root.B", sequence="GGCLVK"))
+
+        self.assertEqual(len(multi_fasta.sequences), 2)
+        self.assertEqual(multi_fasta.label_map["root.A"], "root.A")
+        self.assertEqual(multi_fasta.label_map["root.B"], "root.B")
+
+
+class TestMultiFastaWriteEmbeddings(unittest.TestCase):
+    def test_writes_one_file_per_label_including_deduped(self):
+        multi_fasta = MultiFasta()
+        multi_fasta.add(Sequence(label="root.A", sequence="MKTAYI"))
+        multi_fasta.add(Sequence(label="root.B", sequence="MKTAYI"))  # dupe of A
+        multi_fasta.add(Sequence(label="root.C", sequence="GGCLVK"))
+
+        tensor_ab = torch.rand(6, 4)
+        tensor_c = torch.rand(6, 4)
+        embeddings = [("MKTAYI", tensor_ab), ("GGCLVK", tensor_c)]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            saved_files = multi_fasta.write_embeddings(embeddings, output_dir)
+
+            self.assertEqual(
+                {p.name for p in saved_files},
+                {"root.A.pt", "root.B.pt", "root.C.pt"},
+            )
+
+            for label in ("root.A", "root.B"):
+                result = torch.load(output_dir / f"{label}.pt")
+                self.assertTrue(torch.equal(result["representations"][33], tensor_ab))
+
+            result_c = torch.load(output_dir / "root.C.pt")
+            self.assertTrue(torch.equal(result_c["representations"][33], tensor_c))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR refactors the cli and embedding pipeline to support multiple, multi-chain, multi-model PDB inputs in a single run.

before you had 
```bash
$ deeprank-gnn-esm-predict <pdb_file> <chain_id_1> <chain_id_2> <num_cores>
```

You would need to give it specifically which chain of a given PDB you would use - this works fine but it gets a bit more complex if you are dealing with multiple inputs as their chains might not all be the same.

Internally the chains assigned here would become `A/B` and the pair would be evaluated - I changed the logic so that all chains will be evaluated, in case a multi-chain model is input, the combination of all is checked.

There was also some unnecessary I/O operations saving the fasta sequences to disk - I've changed it so the object is passed instead. It would also create a directory and dump several files there that are side-products of the calculations, while the only result file is the `GNN_esm_prediction.csv`, so I changed to default the intermediate files to the temporary directory - but as I understand you might want to look at the files for debugging, I've added an optional `--output-dir`

main cli now is:

```bash
$ deeprank-gnn-esm-predict <pdb_files...> [--num_cores N] [--output-dir DIR]
```

the format of the output has also been changed to account for the chains, so from:

```diff
- pdb_id,predicted_fnat
+ pdb_id,chain_i,chain_j,predicted_fnat
``` 

as for the code structure I made several changed to make this application more ergonomic - there was a huge main logic which is now split into `input.py`, `sequence.py` and `logger.py`, all with their own class constructors.

I also added some ai-generated tests (manually checked) and updated the CI to account for the changes.

This PR also closes #36 since after this `deeprank-gnn-esm` can handle heterogenous inputs.

> [!NOTE]  
> Since this changes the cli and the output, it's a major version change, so the code will now go up to `v2.0.0`
